### PR TITLE
refactor: migrate to smooks-2.0.xsd

### DIFF
--- a/src/main/java/org/smooks/cartridges/persistence/DaoFlusher.java
+++ b/src/main/java/org/smooks/cartridges/persistence/DaoFlusher.java
@@ -84,7 +84,7 @@ import java.util.Optional;
  * <h3>Configuration Example</h3>
  * <pre>
  * &lt;?xml version=&quot;1.0&quot;?&gt;
- * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-1.2.xsd&quot;
+ * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-2.0.xsd&quot;
  *   xmlns:dao=&quot;https://www.smooks.org/xsd/smooks/persistence-2.0.xsd&quot;&gt;
  *
  *      &lt;dao:flusher dao=&quot;dao&quot; flushOnElement=&quot;root&quot; flushBefore=&quot;false&quot; /&gt;

--- a/src/main/java/org/smooks/cartridges/persistence/EntityDeleter.java
+++ b/src/main/java/org/smooks/cartridges/persistence/EntityDeleter.java
@@ -107,7 +107,7 @@ import java.util.Set;
  * <h3>Configuration Example</h3>
  * <pre>
  * &lt;?xml version=&quot;1.0&quot;?&gt;
- * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-1.2.xsd&quot;
+ * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-2.0.xsd&quot;
  *   xmlns:dao=&quot;https://www.smooks.org/xsd/smooks/persistence-2.0.xsd&quot;&gt;
  *
  *      &lt;dao:deleter dao=&quot;dao&quot; name=&quot;deleteIt&quot; beanId=&quot;toDelete1&quot; deleteOnElement=&quot;root&quot; deletedBeanId=&quot;deleted&quot; deleteBefore=&quot;false&quot; /&gt;

--- a/src/main/java/org/smooks/cartridges/persistence/EntityInserter.java
+++ b/src/main/java/org/smooks/cartridges/persistence/EntityInserter.java
@@ -105,7 +105,7 @@ import java.util.Set;
  * <h3>Configuration Example</h3>
  * <pre>
  * &lt;?xml version=&quot;1.0&quot;?&gt;
- * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-1.2.xsd&quot;
+ * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-2.0.xsd&quot;
  *   xmlns:dao=&quot;https://www.smooks.org/xsd/smooks/persistence-2.0.xsd&quot;&gt;
  *
  *      &lt;dao:inserter dao=&quot;dao&quot; name=&quot;insertIt&quot; beanId=&quot;toInsert&quot; insertOnElement=&quot;root&quot; insertBeanId=&quot;inserted&quot; insertBefore=&quot;false&quot; /&gt;

--- a/src/main/java/org/smooks/cartridges/persistence/EntityLocator.java
+++ b/src/main/java/org/smooks/cartridges/persistence/EntityLocator.java
@@ -92,7 +92,7 @@ import java.util.Set;
  * <h3>Configuration Example</h3>
  * <pre>
  * &lt;?xml version=&quot;1.0&quot;?&gt;
- * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-1.2.xsd&quot;
+ * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-2.0.xsd&quot;
  *    xmlns:dao=&quot;https://www.smooks.org/xsd/smooks/persistence-2.0.xsd&quot;&gt;
  *      &lt;dao:locator beanId=&quot;entity&quot; lookup=&quot;something&quot; lookupOnElement=&quot;b&quot;&gt;
  *      &lt;dao:params&gt;

--- a/src/main/java/org/smooks/cartridges/persistence/EntityUpdater.java
+++ b/src/main/java/org/smooks/cartridges/persistence/EntityUpdater.java
@@ -106,7 +106,7 @@ import java.util.Set;
  * <h3>Configuration Example</h3>
  * <pre>
  * &lt;?xml version=&quot;1.0&quot;?&gt;
- * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-1.2.xsd&quot;
+ * &lt;smooks-resource-list xmlns=&quot;https://www.smooks.org/xsd/smooks-2.0.xsd&quot;
  *   xmlns:dao=&quot;https://www.smooks.org/xsd/smooks/persistence-2.0.xsd&quot;&gt;
  *
  *      &lt;dao:updater dao=&quot;dao&quot; name=&quot;updateIt&quot; beanId=&quot;toUpdate&quot; updateOnElement=&quot;root&quot; updateBeanId=&quot;updated&quot; updateBefore=&quot;false&quot; /&gt;

--- a/src/main/resources/META-INF/LICENSE.Apache-2.0
+++ b/src/main/resources/META-INF/LICENSE.Apache-2.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/main/resources/META-INF/LICENSE.LGPL-3.0-or-later
+++ b/src/main/resources/META-INF/LICENSE.LGPL-3.0-or-later
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/src/main/resources/META-INF/xsd/smooks/persistence-2.0.xsd
+++ b/src/main/resources/META-INF/xsd/smooks/persistence-2.0.xsd
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:smooks="https://www.smooks.org/xsd/smooks-1.2.xsd"
-           xmlns:smooks-persistence="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd"
+           xmlns:smooks="https://www.smooks.org/xsd/smooks-2.0.xsd"
+           xmlns:persistence="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd"
            targetNamespace="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd"
            elementFormDefault="qualified">
 
-    <xs:import namespace="https://www.smooks.org/xsd/smooks-1.2.xsd"/>
+    <xs:import namespace="https://www.smooks.org/xsd/smooks-2.0.xsd"/>
 
     <xs:annotation>
         <xs:documentation xml:lang="en">Smooks Persistence Configuration</xs:documentation>
     </xs:annotation>
 
-    <xs:element name="inserter" type="smooks-persistence:inserter" substitutionGroup="smooks:abstract-resource-config">
+    <xs:element name="inserter" type="persistence:inserter" substitutionGroup="smooks:abstract-resource-config">
     	<xs:annotation>
 			<xs:documentation xml:lang="en">
 				This DAO inserter calls the insert method of a DAO, using a entity bean from
@@ -74,13 +74,6 @@
        					</xs:documentation>
        				</xs:annotation>
        			</xs:attribute>
-       			<xs:attribute name="insertOnElementNS" type="xs:anyURI">
-       				<xs:annotation>
-       					<xs:documentation xml:lang="en">
-       						Namespace control for the "InsertOnElement" attribute.
-       					</xs:documentation>
-       				</xs:annotation>
-       			</xs:attribute>
 				<xs:attribute name="insertBefore" type="xs:boolean" use="optional" default="false">
        				<xs:annotation>
        					<xs:documentation xml:lang="en">
@@ -93,7 +86,7 @@
 
     </xs:complexType>
 
-	<xs:element name="updater" type="smooks-persistence:updater" substitutionGroup="smooks:abstract-resource-config">
+	<xs:element name="updater" type="persistence:updater" substitutionGroup="smooks:abstract-resource-config">
     	<xs:annotation>
 			<xs:documentation xml:lang="en">
 			</xs:documentation>
@@ -151,13 +144,6 @@
        					</xs:documentation>
        				</xs:annotation>
        			</xs:attribute>
-       			<xs:attribute name="updateOnElementNS" type="xs:anyURI">
-       				<xs:annotation>
-       					<xs:documentation xml:lang="en">
-       						Namespace control for the "updateOnElement" attribute.
-       					</xs:documentation>
-       				</xs:annotation>
-       			</xs:attribute>
 				<xs:attribute name="updateBefore" type="xs:boolean" use="optional" default="false">
        				<xs:annotation>
        					<xs:documentation xml:lang="en">
@@ -170,7 +156,7 @@
 
     </xs:complexType>
 
-    <xs:element name="deleter" type="smooks-persistence:deleter" substitutionGroup="smooks:abstract-resource-config">
+    <xs:element name="deleter" type="persistence:deleter" substitutionGroup="smooks:abstract-resource-config">
     	<xs:annotation>
 			<xs:documentation xml:lang="en">
 				This DAO deleter calls the delete method of a DAO, using a entity bean from
@@ -230,13 +216,6 @@
        					</xs:documentation>
        				</xs:annotation>
        			</xs:attribute>
-       			<xs:attribute name="deleteOnElementNS" type="xs:anyURI">
-       				<xs:annotation>
-       					<xs:documentation xml:lang="en">
-       						Namespace control for the "deleteOnElement" attribute.
-       					</xs:documentation>
-       				</xs:annotation>
-       			</xs:attribute>
 				<xs:attribute name="deleteBefore" type="xs:boolean" use="optional" default="false">
        				<xs:annotation>
        					<xs:documentation xml:lang="en">
@@ -249,7 +228,7 @@
 
     </xs:complexType>
 
-    <xs:element name="flusher" type="smooks-persistence:flusher" substitutionGroup="smooks:abstract-resource-config">
+    <xs:element name="flusher" type="persistence:flusher" substitutionGroup="smooks:abstract-resource-config">
     	<xs:annotation>
 			<xs:documentation xml:lang="en">
 				This DAO flusher calls the flush method of a DAO.
@@ -280,13 +259,6 @@
        					</xs:documentation>
        				</xs:annotation>
        			</xs:attribute>
-       			<xs:attribute name="flushOnElementNS" type="xs:anyURI">
-       				<xs:annotation>
-       					<xs:documentation xml:lang="en">
-       						Namespace control for the "flushOnElement" attribute.
-       					</xs:documentation>
-       				</xs:annotation>
-       			</xs:attribute>
 				<xs:attribute name="flushBefore" type="xs:boolean" use="optional" default="false">
        				<xs:annotation>
        					<xs:documentation xml:lang="en">
@@ -299,7 +271,7 @@
 
     </xs:complexType>
 
-    <xs:element name="locator" type="smooks-persistence:locator" substitutionGroup="smooks:abstract-resource-config">
+    <xs:element name="locator" type="persistence:locator" substitutionGroup="smooks:abstract-resource-config">
     	<xs:annotation>
 			<xs:documentation xml:lang="en">
 				Can locate data/records by execution lookup methods or invoking
@@ -344,7 +316,7 @@
     						</xs:documentation>
     					</xs:annotation>
     				</xs:element>
-    				<xs:element name="params" type="smooks-persistence:parameters" maxOccurs="1" minOccurs="0">
+    				<xs:element name="params" type="persistence:parameters" maxOccurs="1" minOccurs="0">
     					<xs:annotation>
     						<xs:documentation xml:lang="en">
     							The lookup method/query parameters.
@@ -375,7 +347,7 @@
     				</xs:annotation>
     			</xs:attribute>
     			<xs:attribute name="onNoResult"
-    				type="smooks-persistence:OnNoResult" use="optional"	default="NULLIFY">
+    				type="persistence:OnNoResult" use="optional"	default="NULLIFY">
     				<xs:annotation>
     					<xs:documentation xml:lang="en">
 							Defines the action when no result is found.
@@ -399,14 +371,6 @@
                             for the bean creator that wires the result of this lookup and use the
                             same selector. This only works if the bean creator is defined before the locator in
                             the configuration.
-    					</xs:documentation>
-    				</xs:annotation>
-    			</xs:attribute>
-    			<xs:attribute name="lookupOnElementNS"
-    				type="xs:anyURI">
-    				<xs:annotation>
-    					<xs:documentation xml:lang="en">
-    						Namespace control for the "lookupOnElement" attribute.
     					</xs:documentation>
     				</xs:annotation>
     			</xs:attribute>
@@ -470,7 +434,7 @@
     		</xs:documentation>
     	</xs:annotation>
     	<xs:choice maxOccurs="unbounded" minOccurs="1">
-    		<xs:element name="value" type="smooks-persistence:valueParameter">
+    		<xs:element name="value" type="persistence:valueParameter">
     			<xs:annotation>
     				<xs:documentation xml:lang="en">
     					A value parameter that retrieves its value
@@ -478,14 +442,14 @@
     				</xs:documentation>
     			</xs:annotation>
     		</xs:element>
-    		<xs:element name="wiring" type="smooks-persistence:wiringParameter">
+    		<xs:element name="wiring" type="persistence:wiringParameter">
     			<xs:annotation>
     				<xs:documentation xml:lang="en">
     					Uses an object from the bean context as parameter.
     				</xs:documentation>
     			</xs:annotation>
     		</xs:element>
-    		<xs:element name="expression"  type="smooks-persistence:expressionParameter">
+    		<xs:element name="expression"  type="persistence:expressionParameter">
     			<xs:annotation>
     				<xs:documentation xml:lang="en">
     					Uses the result from a MVEL expression as parameter.
@@ -496,7 +460,7 @@
     			</xs:annotation>
     		</xs:element>
     	</xs:choice>
-    	<xs:attribute name="type" type="smooks-persistence:parameterType" default="NAMED">
+    	<xs:attribute name="type" type="persistence:parameterType" default="NAMED">
 			<xs:annotation>
 				<xs:documentation xml:lang="en">
 					If the parameters are named or positional.
@@ -513,7 +477,7 @@
     		</xs:documentation>
     	</xs:annotation>
 		<xs:sequence>
-			<xs:element name="decodeParam" type="smooks-persistence:decoderParameter"
+			<xs:element name="decodeParam" type="persistence:decoderParameter"
 				maxOccurs="1"
 				minOccurs="0">
 				<xs:annotation>
@@ -552,13 +516,6 @@
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="dataNS" type="xs:string" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					The namespace for the data selector.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="wiringParameter">
@@ -587,13 +544,6 @@
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
- 		<xs:attribute name="wireOnElementNS" type="xs:string">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					The namespace of the wireOnElement selector.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="expressionParameter">
@@ -613,13 +563,6 @@
 							The element on which the expression will be executed.
 							By default this happens on the
 							same element the locator is defined one.
-						</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-        		<xs:attribute name="execOnElementNS" type="xs:string">
-					<xs:annotation>
-						<xs:documentation xml:lang="en">
-							The namespace of the execOnElement selector.
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>

--- a/src/main/resources/META-INF/xsd/smooks/persistence-2.0.xsd-smooks.xml
+++ b/src/main/resources/META-INF/xsd/smooks/persistence-2.0.xsd-smooks.xml
@@ -42,250 +42,221 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd" default-selector-namespace="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd" 
+                      xmlns:persistence="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<!-- INSERTER -->
 
-    <resource-config selector="inserter">
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cdr.extension.NewResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.EntityInserter</param>
     </resource-config>
 
-    <resource-config selector="inserter">
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">insertOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="inserter">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">insertOnElementNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="inserter">
+    
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">beanId</param>
     </resource-config>
 
-    <resource-config selector="inserter">
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">insertedBeanId</param>
     </resource-config>
 
-    <resource-config selector="inserter">
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">dao</param>
     </resource-config>
 
-    <resource-config selector="inserter">
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">name</param>
     </resource-config>
 
-    <resource-config selector="inserter">
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">insertBefore</param>
     </resource-config>
 
-    <resource-config selector="inserter">
+    <resource-config selector="persistence:inserter">
         <resource>org.smooks.cartridges.persistence.config.ext.SetSelectorFromBeanCreator</resource>
         <param name="selectorAttrName">insertOnElement</param>
     </resource-config>
 
 	<!-- UPDATER -->
 
-    <resource-config selector="updater">
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cdr.extension.NewResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.EntityUpdater</param>
     </resource-config>
 
-    <resource-config selector="updater">
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">updateOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="updater">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">updateOnElementNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="updater">
+    
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">beanId</param>
     </resource-config>
 
-    <resource-config selector="updater">
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">updatedBeanId</param>
     </resource-config>
 
-    <resource-config selector="updater">
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">dao</param>
     </resource-config>
 
-    <resource-config selector="updater">
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">name</param>
     </resource-config>
 
-    <resource-config selector="updater">
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">updateBefore</param>
     </resource-config>
 
-    <resource-config selector="updater">
+    <resource-config selector="persistence:updater">
         <resource>org.smooks.cartridges.persistence.config.ext.SetSelectorFromBeanCreator</resource>
         <param name="selectorAttrName">updateOnElement</param>
     </resource-config>
 
 	<!-- DELETER -->
 
-    <resource-config selector="deleter">
+    <resource-config selector="persistence:deleter">
         <resource>org.smooks.cdr.extension.NewResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.EntityDeleter</param>
     </resource-config>
 
-    <resource-config selector="deleter">
+    <resource-config selector="persistence:deleter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">deleteOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="deleter">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">deleteOnElementNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="deleter">
+    
+    <resource-config selector="persistence:deleter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">beanId</param>
     </resource-config>
 
-    <resource-config selector="deleter">
+    <resource-config selector="persistence:deleter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">deletedBeanId</param>
     </resource-config>
 
-    <resource-config selector="deleter">
+    <resource-config selector="persistence:deleter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">dao</param>
     </resource-config>
 
-    <resource-config selector="deleter">
+    <resource-config selector="persistence:deleter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">name</param>
     </resource-config>
 
-    <resource-config selector="deleter">
+    <resource-config selector="persistence:deleter">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">deleteBefore</param>
     </resource-config>
 
     <!-- FLUSHER -->
 
-    <resource-config selector="flusher">
+    <resource-config selector="persistence:flusher">
         <resource>org.smooks.cdr.extension.NewResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.DaoFlusher</param>
     </resource-config>
 
-    <resource-config selector="flusher">
+    <resource-config selector="persistence:flusher">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">flushOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="flusher">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">flushOnElementNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="flusher">
+    
+    <resource-config selector="persistence:flusher">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">dao</param>
     </resource-config>
 
-    <resource-config selector="flusher">
+    <resource-config selector="persistence:flusher">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">flushBefore</param>
     </resource-config>
 
     <!-- Locator -->
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cdr.extension.NewResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.EntityLocator</param>
     </resource-config>
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cartridges.persistence.config.ext.EntityLocatorIdResolver</resource>
     </resource-config>
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">lookupOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="locator">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">lookupOnElementNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="locator">
+    
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">beanId</param>
 	</resource-config>
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">dao</param>
     </resource-config>
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">lookup</param>
     </resource-config>
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">onNoResult</param>
     </resource-config>
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">uniqueResult</param>
     </resource-config>
 
-    <resource-config selector="locator">
+    <resource-config selector="persistence:locator">
         <resource>org.smooks.cartridges.persistence.config.ext.SetSelectorFromBeanPopulatorWiring</resource>
         <param name="selectorAttrName">lookupOnElement</param>
     </resource-config>
 
-	<resource-config selector="locator/query">
+	<resource-config selector="persistence:locator/query">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromText</resource>
         <param name="mapTo">query</param>
     </resource-config>
 
-    <resource-config selector="locator/params">
+    <resource-config selector="persistence:locator/params">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">type</param>
         <param name="mapTo">parameterListType</param>
     </resource-config>
 
-    <resource-config selector="locator/params">
+    <resource-config selector="persistence:locator/params">
         <resource>org.smooks.cartridges.persistence.config.ext.ParameterIndexInitializer</resource>
     </resource-config>
 
 	<!-- LOOKUPPER - Value Parameter  -->
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cdr.extension.CloneResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.EntityLocatorParameterVisitor</param>
         <param name="unset">beanId</param>
@@ -297,56 +268,50 @@
         <param name="unset">id</param>
     </resource-config>
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cartridges.persistence.config.ext.ParameterIndexResolver</resource>
     </resource-config>
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromParentConfig</resource>
         <param name="mapFrom">id</param>
         <param name="mapTo">entityLookupperId</param>
     </resource-config>
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">data</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="locator/params/value">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">dataNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="locator/params/value">
+    
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">name</param>
     </resource-config>
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">decoder</param>
         <param name="mapTo">type</param>
         <param name="defaultValue">String</param>
     </resource-config>
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">default</param>
     </resource-config>
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cartridges.javabean.ext.SelectorPropertyResolver</resource>
     </resource-config>
 
-    <resource-config selector="locator/params/value">
+    <resource-config selector="persistence:locator/params/value">
         <resource>org.smooks.cartridges.persistence.config.ext.DecodeParamResolver</resource>
     </resource-config>
 
 	<!-- LOOKUPPER - Wiring Parameter -->
 
-    <resource-config selector="locator/params/wiring">
+    <resource-config selector="persistence:locator/params/wiring">
         <resource>org.smooks.cdr.extension.CloneResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.EntityLocatorParameterVisitor</param>
         <param name="unset">beanId</param>
@@ -358,34 +323,28 @@
         <param name="unset">id</param>
     </resource-config>
 
-    <resource-config selector="locator/params/wiring">
+    <resource-config selector="persistence:locator/params/wiring">
         <resource>org.smooks.cartridges.persistence.config.ext.ParameterIndexResolver</resource>
     </resource-config>
 
-    <resource-config selector="locator/params/wiring">
+    <resource-config selector="persistence:locator/params/wiring">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromParentConfig</resource>
         <param name="mapFrom">id</param>
         <param name="mapTo">entityLookupperId</param>
     </resource-config>
 
-    <resource-config selector="locator/params/wiring">
+    <resource-config selector="persistence:locator/params/wiring">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">wireOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="locator/params/wiring">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">wireOnElementNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="locator/params/wiring">
+    
+    <resource-config selector="persistence:locator/params/wiring">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">name</param>
     </resource-config>
 
-    <resource-config selector="locator/params/wiring">
+    <resource-config selector="persistence:locator/params/wiring">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">beanIdRef</param>
         <param name="mapTo">wireBeanId</param>
@@ -393,7 +352,7 @@
 
     <!-- LOOKUPPER - Expression Parameter  -->
 
-    <resource-config selector="locator/params/expression">
+    <resource-config selector="persistence:locator/params/expression">
         <resource>org.smooks.cdr.extension.CloneResourceConfig</resource>
         <param name="resource">org.smooks.cartridges.persistence.EntityLocatorParameterVisitor</param>
         <param name="unset">beanId</param>
@@ -405,36 +364,29 @@
         <param name="unset">id</param>
     </resource-config>
 
-    <resource-config selector="locator/params/expression">
+    <resource-config selector="persistence:locator/params/expression">
         <resource>org.smooks.cartridges.persistence.config.ext.ParameterIndexResolver</resource>
     </resource-config>
 
-    <resource-config selector="locator/params/expression">
+    <resource-config selector="persistence:locator/params/expression">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromParentConfig</resource>
         <param name="mapFrom">id</param>
         <param name="mapTo">entityLookupperId</param>
     </resource-config>
 
 
-    <resource-config selector="locator/params/expression">
+    <resource-config selector="persistence:locator/params/expression">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">execOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
-
-    <resource-config selector="locator/params/expression">
-        <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">execOnElementNS</param>
-        <param name="mapTo">selector-namespace</param>
-    </resource-config>
-
-    <resource-config selector="locator/params/expression">
+    
+    <resource-config selector="persistence:locator/params/expression">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">name</param>
     </resource-config>
-
-
-    <resource-config selector="locator/params/expression">
+    
+    <resource-config selector="persistence:locator/params/expression">
         <resource>org.smooks.cdr.extension.MapToResourceConfigFromText</resource>
         <param name="mapTo">expression</param>
     </resource-config>

--- a/src/test/java/org/smooks/cartridges/persistence/config/ext14/entity-inserter-no-selector.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/config/ext14/entity-inserter-no-selector.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 					  xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
 					  xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 

--- a/src/test/java/org/smooks/cartridges/persistence/config/ext14/entity-locator-no-selector.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/config/ext14/entity-locator-no-selector.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
                       xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 

--- a/src/test/java/org/smooks/cartridges/persistence/config/ext14/entity-updater-no-selector.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/config/ext14/entity-updater-no-selector.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 					  xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
 					  xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 

--- a/src/test/java/org/smooks/cartridges/persistence/doa-flusher-01.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/doa-flusher-01.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:flusher flushOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/doa-flusher-02.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/doa-flusher-02.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:flusher dao="dao1" flushOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/doa-flusher-03.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/doa-flusher-03.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:flusher dao="dao" flushOnElement="root" flushBefore="false" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-deleter-01.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-deleter-01.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:deleter beanId="toDelete1" deleteOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-deleter-02.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-deleter-02.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:deleter beanId="toDelete1" dao="dao1" deleteOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-deleter-03.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-deleter-03.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:deleter beanId="toDelete1"  deletedBeanId="deleted1"  deleteOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-deleter-04.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-deleter-04.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:deleter beanId="toDelete1" name="delete1" deleteOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-deleter-05.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-deleter-05.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:deleter beanId="toDelete1"  deleteOnElement="root" deleteBefore="true" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-deleter-06.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-deleter-06.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 

--- a/src/test/java/org/smooks/cartridges/persistence/entity-inserter-01.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-inserter-01.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:inserter beanId="toInsert1" insertOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-inserter-02.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-inserter-02.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:inserter beanId="toInsert1" dao="dao1" insertOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-inserter-03.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-inserter-03.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:inserter beanId="toInsert1" insertedBeanId="inserted1" insertOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-inserter-04.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-inserter-04.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:inserter beanId="toInsert1" name="insert1" insertOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-inserter-05.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-inserter-05.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:inserter beanId="toInsert1"  insertOnElement="root" insertBefore="true" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-inserter-06.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-inserter-06.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 

--- a/src/test/java/org/smooks/cartridges/persistence/entity-locator-01.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-locator-01.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 

--- a/src/test/java/org/smooks/cartridges/persistence/entity-locator-02.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-locator-02.xml
@@ -42,9 +42,8 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
-	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
-	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+					  xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:locator beanId="entity" lookupOnElement="#document" onNoResult="NULLIFY" uniqueResult="true">
 		<dao:query>from SomeThing</dao:query>

--- a/src/test/java/org/smooks/cartridges/persistence/entity-locator-03.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-locator-03.xml
@@ -42,9 +42,8 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
-	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
-	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+					  xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:locator beanId="entity" lookupOnElement="#document" onNoResult="EXCEPTION" uniqueResult="true">
 		<dao:query>from SomeThing</dao:query>

--- a/src/test/java/org/smooks/cartridges/persistence/entity-locator-04.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-locator-04.xml
@@ -42,9 +42,8 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
-	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
-	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+					  xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:locator beanId="entity" lookupOnElement="#document" >
 		<dao:query>from SomeThing where arg1=:1 and arg2=:2</dao:query>

--- a/src/test/java/org/smooks/cartridges/persistence/entity-locator-05.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-locator-05.xml
@@ -42,9 +42,8 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
-	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
-	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+					  xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:locator dao="some" lookup="test" beanId="entity" lookupOnElement="#document" >
 		<dao:params type="POSITIONAL">

--- a/src/test/java/org/smooks/cartridges/persistence/entity-updater-01.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-updater-01.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:updater beanId="toUpdate1" updateOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-updater-02.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-updater-02.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:updater beanId="toUpdate1" dao="dao1" updateOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-updater-03.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-updater-03.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:updater beanId="toUpdate1"  updatedBeanId="updated1"  updateOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-updater-04.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-updater-04.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:updater beanId="toUpdate1" name="update1" updateOnElement="root" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-updater-05.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-updater-05.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 
 	<dao:updater beanId="toUpdate1"  updateOnElement="root" updateBefore="true" />

--- a/src/test/java/org/smooks/cartridges/persistence/entity-updater-06.xml
+++ b/src/test/java/org/smooks/cartridges/persistence/entity-updater-06.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
 	xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd"
 	xmlns:dao="https://www.smooks.org/xsd/smooks/persistence-2.0.xsd">
 

--- a/src/test/resources/dao-smooks-config.xml
+++ b/src/test/resources/dao-smooks-config.xml
@@ -42,7 +42,7 @@
   =========================LICENSE_END==================================
   -->
 
-<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.5.xsd"
                       xmlns:jb="https://www.smooks.org/xsd/smooks/javabean-1.6.xsd">
     


### PR DESCRIPTION
copy licenses to META-INF directory in order to include licenses with binary archives

BREAKING CHANGE: remove the following XML attributes from persistence-2.0.xsd: insertOnElementNS, updateOnElementNS, deleteOnElementNS, flusher@flushOnElementNS, lookupOnElementNS, dataNS, wireOnElementNS, execOnElementNS